### PR TITLE
Add multilingual API docs

### DIFF
--- a/demo/client/index.html
+++ b/demo/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LLM SSE Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/demo/client/package.json
+++ b/demo/client/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "llm-sse-demo",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "antd": "^5.8.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/demo/client/src/App.tsx
+++ b/demo/client/src/App.tsx
@@ -1,0 +1,22 @@
+import { Layout, Typography } from 'antd';
+import Basic from './examples/Basic';
+import CustomSpeed from './examples/CustomSpeed';
+import MultiCall from './examples/MultiCall';
+
+const { Header, Content } = Layout;
+
+export default function App() {
+  return (
+    <Layout>
+      <Header style={{ color: '#fff' }}>LLM SSE Demo</Header>
+      <Content style={{ padding: 24 }}>
+        <Typography.Title level={2}>Basic</Typography.Title>
+        <Basic />
+        <Typography.Title level={2}>Custom Speed</Typography.Title>
+        <CustomSpeed />
+        <Typography.Title level={2}>Multiple Calls</Typography.Title>
+        <MultiCall />
+      </Content>
+    </Layout>
+  );
+}

--- a/demo/client/src/examples/Basic.tsx
+++ b/demo/client/src/examples/Basic.tsx
@@ -1,0 +1,27 @@
+import { Button, Card } from 'antd';
+import React, { useRef } from 'react';
+import { streamLLM, Typewriter } from '../../../src/llmStream.js';
+
+export default function Basic() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const onClick = () => {
+    if (!ref.current) return;
+    ref.current.textContent = '';
+    const writer = new Typewriter(ref.current, 30);
+    streamLLM('/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'Hello world from demo' })
+    }, {
+      onToken: t => writer.print(t)
+    });
+  };
+
+  return (
+    <Card style={{ marginBottom: 24 }}>
+      <Button type="primary" onClick={onClick}>Start</Button>
+      <div ref={ref} style={{ marginTop: 16, minHeight: 24 }}></div>
+    </Card>
+  );
+}

--- a/demo/client/src/examples/CustomSpeed.tsx
+++ b/demo/client/src/examples/CustomSpeed.tsx
@@ -1,0 +1,27 @@
+import { Button, Card } from 'antd';
+import React, { useRef } from 'react';
+import { streamLLM, Typewriter } from '../../../src/llmStream.js';
+
+export default function CustomSpeed() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const onClick = () => {
+    if (!ref.current) return;
+    ref.current.textContent = '';
+    const writer = new Typewriter(ref.current, 5);
+    streamLLM('/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'Fast typing speed example' })
+    }, {
+      onToken: t => writer.print(t)
+    });
+  };
+
+  return (
+    <Card style={{ marginBottom: 24 }}>
+      <Button onClick={onClick}>Start Fast</Button>
+      <div ref={ref} style={{ marginTop: 16, minHeight: 24 }}></div>
+    </Card>
+  );
+}

--- a/demo/client/src/examples/MultiCall.tsx
+++ b/demo/client/src/examples/MultiCall.tsx
@@ -1,0 +1,32 @@
+import { Button, Card, Space } from 'antd';
+import React, { useRef } from 'react';
+import { streamLLM, Typewriter } from '../../../src/llmStream.js';
+
+export default function MultiCall() {
+  const ref1 = useRef<HTMLDivElement>(null);
+  const ref2 = useRef<HTMLDivElement>(null);
+
+  const run = (ref: React.RefObject<HTMLDivElement>, prompt: string) => {
+    if (!ref.current) return;
+    ref.current.textContent = '';
+    const writer = new Typewriter(ref.current, 20);
+    streamLLM('/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt })
+    }, {
+      onToken: t => writer.print(t)
+    });
+  };
+
+  return (
+    <Card>
+      <Space>
+        <Button onClick={() => run(ref1, 'First message streaming')}>Call 1</Button>
+        <Button onClick={() => run(ref2, 'Second message streaming')}>Call 2</Button>
+      </Space>
+      <div ref={ref1} style={{ marginTop: 16, minHeight: 24 }}></div>
+      <div ref={ref2} style={{ marginTop: 16, minHeight: 24 }}></div>
+    </Card>
+  );
+}

--- a/demo/client/src/main.tsx
+++ b/demo/client/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import 'antd/dist/reset.css';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/demo/client/tsconfig.json
+++ b/demo/client/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/demo/client/vite.config.ts
+++ b/demo/client/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  server: {
+    port: 5173,
+    proxy: {
+      '/chat': 'http://localhost:3000'
+    }
+  },
+  plugins: [react()]
+});

--- a/demo/server.js
+++ b/demo/server.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const cors = require('cors');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.post('/chat', (req, res) => {
+  res.set({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  res.flushHeaders();
+
+  const text = (req.body.prompt || 'Hello from server').split(/\s+/);
+  let index = 0;
+  const timer = setInterval(() => {
+    if (index < text.length) {
+      const payload = JSON.stringify({ choices: [{ delta: { content: text[index] + ' ' } }] });
+      res.write(`data: ${payload}\n\n`);
+      index++;
+    } else {
+      res.write('data: [DONE]\n\n');
+      clearInterval(timer);
+      res.end();
+    }
+  }, 400);
+});
+
+app.listen(3000, () => {
+  console.log('demo server running on http://localhost:3000');
+});

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,56 @@
-LLM SSE BROWSER
+# LLM SSE Browser
+
+This project provides a small utility for consuming typical LLM streaming
+responses and rendering them with a typewriter effect.
+
+## Usage
+
+```javascript
+import { streamLLM, Typewriter } from './src/llmStream.js';
+
+const outputEl = document.getElementById('output');
+const typewriter = new Typewriter(outputEl, 30);
+
+streamLLM('/api/chat', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ prompt: 'Hello' })
+}, {
+  onToken(token) {
+    typewriter.print(token);
+  },
+  onDone() {
+    console.log('stream finished');
+  }
+});
+```
+
+## API
+
+### streamLLM(url, fetchOptions, handlers)
+Fetch an SSE stream and handle tokens and completion callbacks.
+
+### class Typewriter
+Incrementally prints text inside a DOM element.
+
+### class LLMStreamParser
+Internal parser used by `streamLLM`.
+
+Other languages: [中文](readme_zh.md) | [日本語](readme_ja.md) | [Русский](readme_ru.md)
+
+## Demo
+
+A small example project is provided in the `demo` directory. It contains a Node.js
+server exposing a `/chat` SSE endpoint and a React + TypeScript frontend built
+with Vite and Ant Design. The frontend showcases several examples for consuming
+LLM streams.
+
+```bash
+# run backend
+node demo/server.js
+
+# in another terminal run the frontend
+cd demo/client && npm run dev
+```
+
+Open `http://localhost:5173` in your browser to try the examples.

--- a/readme_ja.md
+++ b/readme_ja.md
@@ -1,0 +1,53 @@
+# LLM SSE ブラウザ
+
+本プロジェクトは、一般的なLLMのストリーミングレスポンスを解析し、タイプライター風に表示するための小さなユーティリティを提供します。
+
+## 使い方
+
+```javascript
+import { streamLLM, Typewriter } from './src/llmStream.js';
+
+const el = document.getElementById('output');
+const typewriter = new Typewriter(el, 30);
+
+streamLLM('/api/chat', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ prompt: 'こんにちは' })
+}, {
+  onToken(token) {
+    typewriter.print(token);
+  },
+  onDone() {
+    console.log('ストリームが終了しました');
+  }
+});
+```
+
+## API ドキュメント
+
+### `streamLLM(url, fetchOptions, handlers)`
+
+指定した `url` からSSEストリームを取得します。`fetchOptions` は `fetch` のオプションと同じ形式です。`handlers` には以下のコールバックを指定します。
+
+- `onToken(token)`：新しいトークンを受け取った際に実行されます。
+- `onDone()`：`[DONE]` を受信するか接続が切断されたときに実行されます。
+
+### `class Typewriter`
+
+`new Typewriter(element, typingSpeed = 20)` でインスタンスを生成します。
+
+- `element`：テキストを表示するDOM要素。
+- `typingSpeed`：1文字を表示する間隔（ミリ秒）。
+- `print(text)`：テキストをキューに追加し、順次表示します。
+
+### `class LLMStreamParser`
+
+SSEデータを処理する内部パーサーです。通常は直接使用する必要はありません。
+
+- `new LLMStreamParser({ onMessage, onDone })`
+  - `onMessage(payload)`：JSONデータを受信したときに実行。
+  - `onDone()`：`[DONE]` を受信したときに実行。
+- `feed(text)`：データチャンクをパーサーに渡します。
+
+他の言語版として `readme_zh.md` と `readme_ru.md` があります。

--- a/readme_ru.md
+++ b/readme_ru.md
@@ -1,0 +1,53 @@
+# LLM SSE Browser
+
+Проект предоставляет небольшой набор инструментов для обработки потоковых ответов LLM и вывода текста эффектом печатной машинки.
+
+## Быстрый старт
+
+```javascript
+import { streamLLM, Typewriter } from './src/llmStream.js';
+
+const el = document.getElementById('output');
+const typewriter = new Typewriter(el, 30);
+
+streamLLM('/api/chat', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ prompt: 'Привет' })
+}, {
+  onToken(token) {
+    typewriter.print(token);
+  },
+  onDone() {
+    console.log('поток завершен');
+  }
+});
+```
+
+## Документация API
+
+### `streamLLM(url, fetchOptions, handlers)`
+
+Получает SSE-поток по указанному `url`. `fetchOptions` полностью совместимы с `fetch`. В `handlers` можно передать:
+
+- `onToken(token)` — вызывается при получении очередного фрагмента текста.
+- `onDone()` — вызывается при получении `[DONE]` или закрытии соединения.
+
+### `class Typewriter`
+
+Конструктор `new Typewriter(element, typingSpeed = 20)` создаёт экземпляр печатной машинки.
+
+- `element` — DOM-элемент для вывода текста.
+- `typingSpeed` — задержка между символами в миллисекундах.
+- `print(text)` — помещает текст в очередь и выводит его посимвольно.
+
+### `class LLMStreamParser`
+
+Внутренний парсер SSE. В большинстве случаев использовать его напрямую не требуется.
+
+- `new LLMStreamParser({ onMessage, onDone })`
+  - `onMessage(payload)` — вызывается при получении JSON-объекта.
+  - `onDone()` — вызывается при получении `[DONE]`.
+- `feed(text)` — передает данные парсеру.
+
+Для других языков см. `readme_zh.md` и `readme_ja.md`.

--- a/readme_zh.md
+++ b/readme_zh.md
@@ -1,0 +1,53 @@
+# LLM SSE 浏览器
+
+该项目提供了一个帮助解析大型语言模型(LLM)常见流式响应的通用工具，并配有打字机式文本输出效果。
+
+## 快速开始
+
+```javascript
+import { streamLLM, Typewriter } from './src/llmStream.js';
+
+const el = document.getElementById('output');
+const typewriter = new Typewriter(el, 30);
+
+streamLLM('/api/chat', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ prompt: '你好' })
+}, {
+  onToken(token) {
+    typewriter.print(token);
+  },
+  onDone() {
+    console.log('流式传输结束');
+  }
+});
+```
+
+## API 说明
+
+### `streamLLM(url, fetchOptions, handlers)`
+
+从给定的 `url` 拉取 SSE 流，`fetchOptions` 与 `fetch` 接口保持一致。`handlers` 包含：
+
+- `onToken(token)`：当解析到新的文本片段时回调。
+- `onDone()`：当服务端发送 `[DONE]` 或连接结束时触发。
+
+### `class Typewriter`
+
+构造函数 `new Typewriter(element, typingSpeed = 20)` 创建一个打字机实例。
+
+- `element`：用来展示文本的 DOM 元素。
+- `typingSpeed`：每个字符的输出间隔，单位毫秒。
+- `print(text)`：将文本加入输出队列并逐字展示。
+
+### `class LLMStreamParser`
+
+内部解析器，用于处理 SSE 数据块。通常无需直接使用。
+
+- `new LLMStreamParser({ onMessage, onDone })`
+  - `onMessage(payload)`：当收到 JSON 数据时触发。
+  - `onDone()`：当收到 `[DONE]` 标记时触发。
+- `feed(text)`：向解析器输入数据片段。
+
+更多语言版本请参阅 `readme_ja.md` 与 `readme_ru.md`。

--- a/src/llmStream.js
+++ b/src/llmStream.js
@@ -1,0 +1,85 @@
+export class LLMStreamParser {
+  constructor({ onMessage, onDone } = {}) {
+    this.onMessage = onMessage;
+    this.onDone = onDone;
+    this.buffer = '';
+  }
+
+  feed(text) {
+    this.buffer += text;
+    const eventDelimiter = '\n\n';
+    let index;
+    while ((index = this.buffer.indexOf(eventDelimiter)) !== -1) {
+      const event = this.buffer.slice(0, index).trim();
+      this.buffer = this.buffer.slice(index + eventDelimiter.length);
+      if (!event) continue;
+      for (const line of event.split('\n')) {
+        if (line.startsWith('data:')) {
+          const data = line.slice('data:'.length).trim();
+          if (data === '[DONE]') {
+            this.onDone && this.onDone();
+            continue;
+          }
+          try {
+            const payload = JSON.parse(data);
+            this.onMessage && this.onMessage(payload);
+          } catch (e) {
+            // ignore malformed JSON
+          }
+        }
+      }
+    }
+  }
+}
+
+export class Typewriter {
+  constructor(element, typingSpeed = 20) {
+    this.el = element;
+    this.speed = typingSpeed;
+    this.queue = [];
+    this.running = false;
+  }
+
+  async _type(text) {
+    for (const char of text) {
+      this.el.textContent += char;
+      await new Promise(r => setTimeout(r, this.speed));
+    }
+  }
+
+  async _run() {
+    this.running = true;
+    while (this.queue.length) {
+      const text = this.queue.shift();
+      await this._type(text);
+    }
+    this.running = false;
+  }
+
+  print(text) {
+    this.queue.push(text);
+    if (!this.running) {
+      this._run();
+    }
+  }
+}
+
+export async function streamLLM(url, fetchOptions, { onToken, onDone } = {}) {
+  const res = await fetch(url, fetchOptions);
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder('utf-8');
+  const parser = new LLMStreamParser({
+    onMessage: msg => {
+      const token = msg.choices?.[0]?.delta?.content;
+      if (token) onToken && onToken(token);
+    },
+    onDone
+  });
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    const chunk = decoder.decode(value, { stream: true });
+    parser.feed(chunk);
+  }
+}


### PR DESCRIPTION
## Summary
- document API usage in `readme.md`
- add `readme_zh.md` with Chinese instructions
- add `readme_ja.md` with Japanese instructions
- add `readme_ru.md` with Russian instructions
- provide a demo project with Node backend and React frontend

## Testing
- `node -e "import('./src/llmStream.js').then(m=>console.log('loaded', Object.keys(m)))"`

------
https://chatgpt.com/codex/tasks/task_e_6864df73a0208324a85aacaf20727dc7