### PR TITLE
Fix code highlight in docs

### DIFF
--- a/docs/client/src/components/ExampleCard.tsx
+++ b/docs/client/src/components/ExampleCard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Card, Button } from 'antd';
 import { CopyOutlined, CodeOutlined } from '@ant-design/icons';
 import Editor from '@monaco-editor/react';
+import 'monaco-editor/min/vs/editor/editor.main.css';
 import { theme } from 'antd';
 
 export default function ExampleCard({ children, code, language = 'typescript', dark = false }: { children: React.ReactNode; code: string; language?: string; dark?: boolean }) {


### PR DESCRIPTION
## Summary
- ensure monaco editor styles are loaded in docs' example cards

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b89da50248324b9f3731deef00787