### PR TITLE
Fix docs homepage text visibility and add details

### DIFF
--- a/docs/client/src/pages/Home.tsx
+++ b/docs/client/src/pages/Home.tsx
@@ -5,7 +5,7 @@ import ParticlesBackground from '../components/ParticlesBackground';
 export default function Home() {
   const navigate = useNavigate();
   return (
-    <div style={{ position: 'relative', height: '80vh', overflow: 'hidden' }}>
+    <div style={{ position: 'relative', height: '80vh', overflow: 'hidden', background: '#000' }}>
       <ParticlesBackground />
       <div
         style={{
@@ -23,6 +23,11 @@ export default function Home() {
         </Typography.Title>
         <Typography.Paragraph style={{ color: '#fff', fontSize: 20 }}>
           在浏览器中优雅地处理流式响应
+        </Typography.Paragraph>
+        <Typography.Paragraph
+          style={{ color: '#fff', fontSize: 16, maxWidth: 600, textAlign: 'center' }}
+        >
+          LLM SSE Browser 有趣地展示了如何使用流式等待信息的简便接口，你可以通过优雅的编辑效果快速集成并展示复杂的 LLM 结果。
         </Typography.Paragraph>
         <Button type="primary" size="large" onClick={() => navigate('/examples')}>立即体验</Button>
       </div>


### PR DESCRIPTION
## Summary
- add black background so homepage text is readable
- provide a longer description on the docs landing page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686b8a0d6060832484938f2c6280c1ca