### PR TITLE
Enable dark theme by default

### DIFF
--- a/docs/client/src/App.tsx
+++ b/docs/client/src/App.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { ConfigProvider, Layout, Menu, Switch, theme, Anchor, Card } from 'antd';
+import React from 'react';
+import { ConfigProvider, Layout, Menu, theme, Anchor, Card } from 'antd';
 import { BrowserRouter, Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import Home from './pages/Home';
 import Examples from './pages/Examples';
@@ -9,7 +9,6 @@ import QuestionBank from './pages/QuestionBank';
 const { Header, Sider, Content } = Layout;
 
 function Shell() {
-  const [dark, setDark] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
   const { token } = theme.useToken();
@@ -21,15 +20,14 @@ function Shell() {
   ] : [];
 
   return (
-    <ConfigProvider theme={{ algorithm: dark ? theme.darkAlgorithm : theme.defaultAlgorithm }}>
+    <ConfigProvider theme={{ algorithm: theme.darkAlgorithm }}>
       <Layout style={{ minHeight: '100vh' }}>
         <Header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <span style={{ color: '#fff', fontSize: 18 }}>LLM SSE 文档</span>
-          <Switch checked={dark} onChange={setDark} checkedChildren="🌙" unCheckedChildren="☀️" />
         </Header>
         <Layout>
           {!isHome && (
-            <Sider width={200} theme={dark ? 'dark' : 'light'}>
+            <Sider width={200} theme="dark">
               <Menu
                 mode="inline"
                 selectedKeys={[location.pathname]}
@@ -51,7 +49,7 @@ function Shell() {
                 <Card style={{ background: token.colorBgContainer }}>
                   <Routes>
                     <Route path="/" element={<Home />} />
-                    <Route path="/examples" element={<Examples dark={dark} />} />
+                    <Route path="/examples" element={<Examples />} />
                     <Route path="/quiz" element={<Quiz />} />
                     <Route path="/bank" element={<QuestionBank />} />
                   </Routes>
@@ -60,7 +58,7 @@ function Shell() {
             </Content>
           </Layout>
           {anchorItems.length > 0 && !isHome && (
-            <Sider width={200} theme={dark ? 'dark' : 'light'} style={{ padding: '16px 0' }}>
+            <Sider width={200} theme="dark" style={{ padding: '16px 0' }}>
               <Anchor items={anchorItems} />
             </Sider>
           )}

--- a/docs/client/src/components/ExampleCard.tsx
+++ b/docs/client/src/components/ExampleCard.tsx
@@ -5,7 +5,7 @@ import Editor from '@monaco-editor/react';
 import 'monaco-editor/min/vs/editor/editor.main.css';
 import { theme } from 'antd';
 
-export default function ExampleCard({ children, code, language = 'typescript', dark = false }: { children: React.ReactNode; code: string; language?: string; dark?: boolean }) {
+export default function ExampleCard({ children, code, language = 'typescript' }: { children: React.ReactNode; code: string; language?: string }) {
   const [open, setOpen] = useState(false);
   const copy = () => navigator.clipboard.writeText(code);
   const { token } = theme.useToken();
@@ -26,7 +26,7 @@ export default function ExampleCard({ children, code, language = 'typescript', d
           <Editor
             height="200px"
             language={language}
-            theme={dark ? 'vs-dark' : 'vs'}
+            theme="vs-dark"
             value={code}
             options={{ readOnly: true, minimap: { enabled: false }, scrollBeyondLastLine: false }}
           />

--- a/docs/client/src/examples/Basic.tsx
+++ b/docs/client/src/examples/Basic.tsx
@@ -7,7 +7,7 @@ const code = `import { Button } from 'antd';
 import React, { useRef } from 'react';
 import { streamLLM, Typewriter } from '../../../../src/llmStream.js';
 
-export default function Basic({ dark = false }: { dark?: boolean }) {
+export default function Basic() {
   const ref = useRef<HTMLDivElement>(null);
 
   const onClick = () => {
@@ -32,7 +32,7 @@ export default function Basic({ dark = false }: { dark?: boolean }) {
 }
 `;
 
-export default function Basic({ dark = false }: { dark?: boolean }) {
+export default function Basic() {
   const ref = useRef<HTMLDivElement>(null);
 
   const onClick = () => {
@@ -49,7 +49,7 @@ export default function Basic({ dark = false }: { dark?: boolean }) {
   };
 
   return (
-    <ExampleCard code={code} language="tsx" dark={dark}>
+    <ExampleCard code={code} language="tsx">
       <Button type="primary" onClick={onClick}>开始</Button>
       <div ref={ref} style={{ marginTop: 16, minHeight: 24 }}></div>
     </ExampleCard>

--- a/docs/client/src/examples/CustomSpeed.tsx
+++ b/docs/client/src/examples/CustomSpeed.tsx
@@ -7,7 +7,7 @@ const code = `import { Button } from 'antd';
 import React, { useRef } from 'react';
 import { streamLLM, Typewriter } from '../../../../src/llmStream.js';
 
-export default function CustomSpeed({ dark = false }: { dark?: boolean }) {
+export default function CustomSpeed() {
   const ref = useRef<HTMLDivElement>(null);
 
   const onClick = () => {
@@ -32,7 +32,7 @@ export default function CustomSpeed({ dark = false }: { dark?: boolean }) {
 }
 `;
 
-export default function CustomSpeed({ dark = false }: { dark?: boolean }) {
+export default function CustomSpeed() {
   const ref = useRef<HTMLDivElement>(null);
 
   const onClick = () => {
@@ -49,7 +49,7 @@ export default function CustomSpeed({ dark = false }: { dark?: boolean }) {
   };
 
   return (
-    <ExampleCard code={code} language="tsx" dark={dark}>
+    <ExampleCard code={code} language="tsx">
       <Button onClick={onClick}>快速开始</Button>
       <div ref={ref} style={{ marginTop: 16, minHeight: 24 }}></div>
     </ExampleCard>

--- a/docs/client/src/examples/MultiCall.tsx
+++ b/docs/client/src/examples/MultiCall.tsx
@@ -7,7 +7,7 @@ const code = `import { Button, Space } from 'antd';
 import React, { useRef } from 'react';
 import { streamLLM, Typewriter } from '../../../../src/llmStream.js';
 
-export default function MultiCall({ dark = false }: { dark?: boolean }) {
+export default function MultiCall() {
   const ref1 = useRef<HTMLDivElement>(null);
   const ref2 = useRef<HTMLDivElement>(null);
 
@@ -37,7 +37,7 @@ export default function MultiCall({ dark = false }: { dark?: boolean }) {
 }
 `;
 
-export default function MultiCall({ dark = false }: { dark?: boolean }) {
+export default function MultiCall() {
   const ref1 = useRef<HTMLDivElement>(null);
   const ref2 = useRef<HTMLDivElement>(null);
 
@@ -55,7 +55,7 @@ export default function MultiCall({ dark = false }: { dark?: boolean }) {
   };
 
   return (
-    <ExampleCard code={code} language="tsx" dark={dark}>
+    <ExampleCard code={code} language="tsx">
       <Space>
         <Button onClick={() => run(ref1, 'First message streaming')}>调用 1</Button>
         <Button onClick={() => run(ref2, 'Second message streaming')}>调用 2</Button>

--- a/docs/client/src/pages/Examples.tsx
+++ b/docs/client/src/pages/Examples.tsx
@@ -3,15 +3,15 @@ import Basic from '../examples/Basic';
 import CustomSpeed from '../examples/CustomSpeed';
 import MultiCall from '../examples/MultiCall';
 
-export default function Examples({ dark = false }: { dark?: boolean }) {
+export default function Examples() {
   return (
     <>
       <Typography.Title id="basic" level={2}>基础用法</Typography.Title>
-      <Basic dark={dark} />
+      <Basic />
       <Typography.Title id="custom-speed" level={2}>自定义速度</Typography.Title>
-      <CustomSpeed dark={dark} />
+      <CustomSpeed />
       <Typography.Title id="multi-call" level={2}>多次调用</Typography.Title>
-      <MultiCall dark={dark} />
+      <MultiCall />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- remove the theme toggle logic
- default the docs site to Ant Design's dark algorithm
- simplify examples to always use the dark code theme

## Testing
- `npm install` and `npm run build` in `docs`
- `npm install` and `npm run build` in `demo`


------
https://chatgpt.com/codex/tasks/task_e_686b8cd02cdc8324912d49a214dba4dc