### PR TITLE
Fix docs readability

### DIFF
--- a/docs/client/src/App.tsx
+++ b/docs/client/src/App.tsx
@@ -46,14 +46,17 @@ function Shell() {
               {isHome ? (
                 <Home />
               ) : (
-                <Card style={{ background: token.colorBgContainer }}>
+                <>
+                  {/* Use light background for content pages */}
+                  <Card style={{ background: '#fff', color: '#000' }}>
                   <Routes>
                     <Route path="/" element={<Home />} />
                     <Route path="/examples" element={<Examples />} />
                     <Route path="/quiz" element={<Quiz />} />
                     <Route path="/bank" element={<QuestionBank />} />
                   </Routes>
-                </Card>
+                  </Card>
+                </>
               )}
             </Content>
           </Layout>

--- a/docs/client/src/components/ExampleCard.tsx
+++ b/docs/client/src/components/ExampleCard.tsx
@@ -11,7 +11,9 @@ export default function ExampleCard({ children, code, language = 'typescript' }:
   const { token } = theme.useToken();
 
   return (
-    <Card style={{ marginBottom: 24, background: token.colorBgContainer }}>
+    <>
+      {/* Light background for readability */}
+      <Card style={{ marginBottom: 24, background: '#f5f5f5', color: '#000' }}>
       {children}
       <div style={{ textAlign: 'right', marginTop: 16 }}>
         <Button type="link" icon={<CodeOutlined />} onClick={() => setOpen(!open)}>
@@ -32,6 +34,7 @@ export default function ExampleCard({ children, code, language = 'typescript' }:
           />
         </div>
       )}
-    </Card>
+      </Card>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- lighten card backgrounds in docs pages so text remains visible
- add fragment wrappers for comment expression

## Testing
- `npm --prefix docs run build`

------
https://chatgpt.com/codex/tasks/task_e_686b914f0dbc8324893fcc85f880aa93