### PR TITLE
Fix card background color

### DIFF
--- a/docs/client/src/App.tsx
+++ b/docs/client/src/App.tsx
@@ -53,7 +53,7 @@ function Shell() {
                     <Route path="/quiz" element={<Quiz />} />
                     <Route path="/bank" element={<QuestionBank />} />
                   </Routes>
-                </Card>
+                  </Card>
               )}
             </Content>
           </Layout>

--- a/docs/client/src/main.tsx
+++ b/docs/client/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import 'antd/dist/reset.css';
+import './styles.css';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/docs/client/src/styles.css
+++ b/docs/client/src/styles.css
@@ -1,0 +1,3 @@
+.ant-card-body {
+  background: #001529 !important;
+}


### PR DESCRIPTION
## Summary
- set `.ant-card-body` background to `#001529`
- revert temporary light backgrounds
- import custom CSS in docs

## Testing
- `npm --prefix docs run build`


------
https://chatgpt.com/codex/tasks/task_e_686b914f0dbc8324893fcc85f880aa93