### PR TITLE
Make docs text white

### DIFF
--- a/docs/client/src/App.tsx
+++ b/docs/client/src/App.tsx
@@ -47,8 +47,8 @@ function Shell() {
                 <Home />
               ) : (
                 <>
-                  {/* Use light background for content pages */}
-                  <Card style={{ background: '#fff', color: '#000' }}>
+                  {/* Use dark background for content pages */}
+                  <Card style={{ background: '#001529', color: '#fff' }}>
                   <Routes>
                     <Route path="/" element={<Home />} />
                     <Route path="/examples" element={<Examples />} />

--- a/docs/client/src/components/ExampleCard.tsx
+++ b/docs/client/src/components/ExampleCard.tsx
@@ -12,8 +12,8 @@ export default function ExampleCard({ children, code, language = 'typescript' }:
 
   return (
     <>
-      {/* Light background for readability */}
-      <Card style={{ marginBottom: 24, background: '#f5f5f5', color: '#000' }}>
+      {/* Dark background for unified white text */}
+      <Card style={{ marginBottom: 24, background: '#001529', color: '#fff' }}>
       {children}
       <div style={{ textAlign: 'right', marginTop: 16 }}>
         <Button type="link" icon={<CodeOutlined />} onClick={() => setOpen(!open)}>

--- a/docs/client/src/styles.css
+++ b/docs/client/src/styles.css
@@ -1,3 +1,13 @@
+body {
+  color: #ffffff;
+}
+
 .ant-card-body {
   background: #001529 !important;
+  color: #ffffff !important;
+}
+
+.ant-typography,
+.ant-typography * {
+  color: #ffffff !important;
 }


### PR DESCRIPTION
## Summary
- enforce white text styles globally
- update ExampleCard to use a dark background and white text
- update App page cards to use a dark background and white text

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686b97e08d248324a57ea35974951206