### PR TITLE
Add BackTop button to docs

### DIFF
--- a/docs/client/src/App.tsx
+++ b/docs/client/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ConfigProvider, Layout, Menu, theme, Anchor, Card } from 'antd';
+import { ConfigProvider, Layout, Menu, theme, Anchor, Card, BackTop } from 'antd';
 import { BrowserRouter, Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import Home from './pages/Home';
 import Examples from './pages/Examples';
@@ -66,6 +66,7 @@ function Shell() {
             </Sider>
           )}
         </Layout>
+        <BackTop />
       </Layout>
     </ConfigProvider>
   );


### PR DESCRIPTION
## Summary
- add Ant Design BackTop component to docs layout for floating button on all pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` in `docs` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b981b156c8324a950143dae6baaca