### PR TITLE
Add lovework prefix to docs site

### DIFF
--- a/docs/client/index.html
+++ b/docs/client/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/docs/client/src/App.tsx
+++ b/docs/client/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ConfigProvider, Layout, Menu, theme, Anchor, Card, BackTop } from 'antd';
 import { BrowserRouter, Routes, Route, useNavigate, useLocation } from 'react-router-dom';
+import { basePath } from './config';
 import Home from './pages/Home';
 import Examples from './pages/Examples';
 import Quiz from './pages/Quiz';
@@ -77,7 +78,7 @@ function Shell() {
 
 export default function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={basePath}>
       <Shell />
     </BrowserRouter>
   );

--- a/docs/client/src/config.ts
+++ b/docs/client/src/config.ts
@@ -1,0 +1,1 @@
+export const basePath = '/lovework';

--- a/docs/client/src/examples/Basic.tsx
+++ b/docs/client/src/examples/Basic.tsx
@@ -2,6 +2,7 @@ import { Button } from 'antd';
 import React, { useRef } from 'react';
 import { streamLLM, Typewriter } from '../../../../src/llmStream.js';
 import ExampleCard from '../components/ExampleCard';
+import { basePath } from '../config';
 
 const code = `import { Button } from 'antd';
 import React, { useRef } from 'react';
@@ -14,7 +15,7 @@ export default function Basic() {
     if (!ref.current) return;
     ref.current.textContent = '';
     const writer = new Typewriter(ref.current, 30);
-    streamLLM('/chat', {
+    streamLLM('/lovework/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: 'Hello world from docs' })
@@ -39,7 +40,7 @@ export default function Basic() {
     if (!ref.current) return;
     ref.current.textContent = '';
     const writer = new Typewriter(ref.current, 30);
-    streamLLM('/chat', {
+    streamLLM(`${basePath}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: 'Hello world from docs' })

--- a/docs/client/src/examples/CustomSpeed.tsx
+++ b/docs/client/src/examples/CustomSpeed.tsx
@@ -2,6 +2,7 @@ import { Button } from 'antd';
 import React, { useRef } from 'react';
 import { streamLLM, Typewriter } from '../../../../src/llmStream.js';
 import ExampleCard from '../components/ExampleCard';
+import { basePath } from '../config';
 
 const code = `import { Button } from 'antd';
 import React, { useRef } from 'react';
@@ -14,7 +15,7 @@ export default function CustomSpeed() {
     if (!ref.current) return;
     ref.current.textContent = '';
     const writer = new Typewriter(ref.current, 5);
-    streamLLM('/chat', {
+    streamLLM('/lovework/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: 'Fast typing speed example' })
@@ -39,7 +40,7 @@ export default function CustomSpeed() {
     if (!ref.current) return;
     ref.current.textContent = '';
     const writer = new Typewriter(ref.current, 5);
-    streamLLM('/chat', {
+    streamLLM(`${basePath}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: 'Fast typing speed example' })

--- a/docs/client/src/examples/MultiCall.tsx
+++ b/docs/client/src/examples/MultiCall.tsx
@@ -2,6 +2,7 @@ import { Button, Space } from 'antd';
 import React, { useRef } from 'react';
 import { streamLLM, Typewriter } from '../../../../src/llmStream.js';
 import ExampleCard from '../components/ExampleCard';
+import { basePath } from '../config';
 
 const code = `import { Button, Space } from 'antd';
 import React, { useRef } from 'react';
@@ -15,7 +16,7 @@ export default function MultiCall() {
     if (!ref.current) return;
     ref.current.textContent = '';
     const writer = new Typewriter(ref.current, 20);
-    streamLLM('/chat', {
+    streamLLM('/lovework/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt })
@@ -45,7 +46,7 @@ export default function MultiCall() {
     if (!ref.current) return;
     ref.current.textContent = '';
     const writer = new Typewriter(ref.current, 20);
-    streamLLM('/chat', {
+    streamLLM(`${basePath}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt })

--- a/docs/client/src/pages/QuestionBank.tsx
+++ b/docs/client/src/pages/QuestionBank.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Typography, Upload, Button, Table, Modal, Input } from 'antd';
 import * as XLSX from 'xlsx';
+import { basePath } from '../config';
 
 interface Row {
   key: number;
@@ -17,7 +18,7 @@ export default function QuestionBank() {
   const [editing, setEditing] = useState<Row | null>(null);
 
   const load = () => {
-    fetch('/api/questions')
+    fetch(`${basePath}/api/questions`)
       .then(res => res.json())
       .then(rows => setData(rows.map((r: any) => ({ key: r.id, ...r }))));
   };
@@ -40,7 +41,7 @@ export default function QuestionBank() {
         D: r[4],
         answer: r[5]
       }));
-      await fetch('/api/questions', {
+      await fetch(`${basePath}/api/questions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ questions: rows })
@@ -70,14 +71,14 @@ export default function QuestionBank() {
   };
 
   const remove = async (id: number) => {
-    await fetch(`/api/questions/${id}`, { method: 'DELETE' });
+    await fetch(`${basePath}/api/questions/${id}`, { method: 'DELETE' });
     load();
   };
 
   const saveEdit = async () => {
     if (!editing) return;
     const { key, ...payload } = editing;
-    await fetch(`/api/questions/${key}`, {
+    await fetch(`${basePath}/api/questions/${key}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)

--- a/docs/client/src/pages/Quiz.tsx
+++ b/docs/client/src/pages/Quiz.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Typography, Radio, Button } from 'antd';
+import { basePath } from '../config';
 
 interface Question {
   id: number;
@@ -14,7 +15,7 @@ export default function Quiz() {
   const [score, setScore] = useState<number | null>(null);
 
   useEffect(() => {
-    fetch('/api/questions')
+    fetch(`${basePath}/api/questions`)
       .then(res => res.json())
       .then(rows =>
         setQuestions(
@@ -34,7 +35,7 @@ export default function Quiz() {
       if (answers[q.id] === q.answer) sc++;
     });
     setScore(sc);
-    fetch('/api/results', {
+    fetch(`${basePath}/api/results`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ score: sc, total: questions.length })

--- a/docs/client/src/pages/Results.tsx
+++ b/docs/client/src/pages/Results.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Typography, Table } from 'antd';
+import { basePath } from '../config';
 
 interface Result {
   id: number;
@@ -12,7 +13,7 @@ export default function Results() {
   const [data, setData] = useState<Result[]>([]);
 
   useEffect(() => {
-    fetch('/api/results')
+    fetch(`${basePath}/api/results`)
       .then(res => res.json())
       .then(rows => setData(rows));
   }, []);

--- a/docs/server.js
+++ b/docs/server.js
@@ -4,6 +4,7 @@ const { createServer: createViteServer } = require('vite');
 const path = require('path');
 const sqlite3 = require('sqlite3').verbose();
 const dbFile = path.resolve(__dirname, 'questions.db');
+const basePath = '/lovework';
 
 async function start() {
   const app = express();
@@ -29,7 +30,7 @@ async function start() {
     )`);
   });
 
-  app.post('/chat', (req, res) => {
+  app.post(`${basePath}/chat`, (req, res) => {
     res.set({
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
@@ -51,14 +52,14 @@ async function start() {
       }
     }, 400);
   });
-  app.get('/api/questions', (req, res) => {
+  app.get(`${basePath}/api/questions`, (req, res) => {
     db.all('SELECT * FROM questions', (err, rows) => {
       if (err) return res.status(500).json({ error: err.message });
       res.json(rows);
     });
   });
 
-  app.post('/api/questions', (req, res) => {
+  app.post(`${basePath}/api/questions`, (req, res) => {
     const qs = req.body.questions || [];
     const stmt = db.prepare('INSERT INTO questions(question,A,B,C,D,answer) VALUES (?,?,?,?,?,?)');
     db.serialize(() => {
@@ -72,7 +73,7 @@ async function start() {
     });
   });
 
-  app.put('/api/questions/:id', (req, res) => {
+  app.put(`${basePath}/api/questions/:id`, (req, res) => {
     const id = req.params.id;
     const q = req.body;
     db.run(
@@ -85,21 +86,21 @@ async function start() {
     );
   });
 
-  app.delete('/api/questions/:id', (req, res) => {
+  app.delete(`${basePath}/api/questions/:id`, (req, res) => {
     db.run('DELETE FROM questions WHERE id=?', req.params.id, function (err) {
       if (err) return res.status(500).json({ error: err.message });
       res.json({ ok: true });
     });
   });
 
-  app.get('/api/results', (req, res) => {
+  app.get(`${basePath}/api/results`, (req, res) => {
     db.all('SELECT * FROM results ORDER BY id DESC', (err, rows) => {
       if (err) return res.status(500).json({ error: err.message });
       res.json(rows);
     });
   });
 
-  app.post('/api/results', (req, res) => {
+  app.post(`${basePath}/api/results`, (req, res) => {
     const { score, total } = req.body;
     db.run('INSERT INTO results(score,total) VALUES(?,?)', [score, total], function (err) {
       if (err) return res.status(500).json({ error: err.message });
@@ -112,7 +113,7 @@ async function start() {
     server: { middlewareMode: 'html' },
   });
 
-  app.use(vite.middlewares);
+  app.use(basePath, vite.middlewares);
 
   const port = 3000;
   app.listen(port, () => {

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -4,6 +4,7 @@ import { resolve } from 'path';
 
 export default defineConfig({
   root: resolve(__dirname, 'client'),
+  base: '/lovework/',
   build: {
     outDir: resolve(__dirname, 'client/dist')
   },


### PR DESCRIPTION
## Summary
- set up a constant `basePath` for the docs site
- mount Express and React router under `/lovework`
- update Vite config and HTML entry
- prefix API calls and stream endpoints with `/lovework`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686bab6ffb208324aa91b25ed38732f4