### PR TITLE
Fix docs dev base path

### DIFF
--- a/docs/server.js
+++ b/docs/server.js
@@ -109,7 +109,7 @@ async function start() {
   });
 
   const vite = await createViteServer({
-    root: path.resolve(__dirname, 'client'),
+    configFile: path.resolve(__dirname, 'vite.config.ts'),
     server: { middlewareMode: 'html' },
   });
 

--- a/readme.md
+++ b/readme.md
@@ -54,5 +54,5 @@ npm install
 npm run dev
 ```
 
-Open `http://localhost:3000` in your browser to explore the examples and the quiz site. The site now includes a small quiz and a question bank page where you can upload Excel files or download a template to manage questions. The uploaded questions are persisted in a local SQLite database handled by the Node.js server, which exposes CRUD endpoints under `/api/questions`.
+Open `http://localhost:3000/lovework` in your browser to explore the examples and the quiz site. The site now includes a small quiz and a question bank page where you can upload Excel files or download a template to manage questions. The uploaded questions are persisted in a local SQLite database handled by the Node.js server, which exposes CRUD endpoints under `/api/questions`.
 


### PR DESCRIPTION
## Summary
- fix `createViteServer` so Vite config (and base path) is loaded
- update docs instructions to open the `/lovework` base path

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bae96292c8324ba1d9b38687c2644