### PR TITLE
Update API base path

### DIFF
--- a/docs/client/src/config.ts
+++ b/docs/client/src/config.ts
@@ -1,1 +1,2 @@
 export const basePath = '/lovework';
+export const apiBasePath = '/lovework/api';

--- a/docs/client/src/examples/Basic.tsx
+++ b/docs/client/src/examples/Basic.tsx
@@ -2,7 +2,7 @@ import { Button } from 'antd';
 import React, { useRef } from 'react';
 import { streamLLM, Typewriter } from '../../../../src/llmStream.js';
 import ExampleCard from '../components/ExampleCard';
-import { basePath } from '../config';
+import { apiBasePath } from '../config';
 
 const code = `import { Button } from 'antd';
 import React, { useRef } from 'react';
@@ -15,7 +15,7 @@ export default function Basic() {
     if (!ref.current) return;
     ref.current.textContent = '';
     const writer = new Typewriter(ref.current, 30);
-    streamLLM('/lovework/chat', {
+    streamLLM('/lovework/api/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: 'Hello world from docs' })
@@ -40,7 +40,7 @@ export default function Basic() {
     if (!ref.current) return;
     ref.current.textContent = '';
     const writer = new Typewriter(ref.current, 30);
-    streamLLM(`${basePath}/chat`, {
+    streamLLM(`${apiBasePath}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: 'Hello world from docs' })

--- a/docs/client/src/examples/CustomSpeed.tsx
+++ b/docs/client/src/examples/CustomSpeed.tsx
@@ -2,7 +2,7 @@ import { Button } from 'antd';
 import React, { useRef } from 'react';
 import { streamLLM, Typewriter } from '../../../../src/llmStream.js';
 import ExampleCard from '../components/ExampleCard';
-import { basePath } from '../config';
+import { apiBasePath } from '../config';
 
 const code = `import { Button } from 'antd';
 import React, { useRef } from 'react';
@@ -15,7 +15,7 @@ export default function CustomSpeed() {
     if (!ref.current) return;
     ref.current.textContent = '';
     const writer = new Typewriter(ref.current, 5);
-    streamLLM('/lovework/chat', {
+    streamLLM('/lovework/api/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: 'Fast typing speed example' })
@@ -40,7 +40,7 @@ export default function CustomSpeed() {
     if (!ref.current) return;
     ref.current.textContent = '';
     const writer = new Typewriter(ref.current, 5);
-    streamLLM(`${basePath}/chat`, {
+    streamLLM(`${apiBasePath}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: 'Fast typing speed example' })

--- a/docs/client/src/examples/MultiCall.tsx
+++ b/docs/client/src/examples/MultiCall.tsx
@@ -2,7 +2,7 @@ import { Button, Space } from 'antd';
 import React, { useRef } from 'react';
 import { streamLLM, Typewriter } from '../../../../src/llmStream.js';
 import ExampleCard from '../components/ExampleCard';
-import { basePath } from '../config';
+import { apiBasePath } from '../config';
 
 const code = `import { Button, Space } from 'antd';
 import React, { useRef } from 'react';
@@ -16,7 +16,7 @@ export default function MultiCall() {
     if (!ref.current) return;
     ref.current.textContent = '';
     const writer = new Typewriter(ref.current, 20);
-    streamLLM('/lovework/chat', {
+    streamLLM('/lovework/api/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt })
@@ -46,7 +46,7 @@ export default function MultiCall() {
     if (!ref.current) return;
     ref.current.textContent = '';
     const writer = new Typewriter(ref.current, 20);
-    streamLLM(`${basePath}/chat`, {
+    streamLLM(`${apiBasePath}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt })

--- a/docs/client/src/pages/QuestionBank.tsx
+++ b/docs/client/src/pages/QuestionBank.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Typography, Upload, Button, Table, Modal, Input } from 'antd';
 import * as XLSX from 'xlsx';
-import { basePath } from '../config';
+import { apiBasePath } from '../config';
 
 interface Row {
   key: number;
@@ -18,7 +18,7 @@ export default function QuestionBank() {
   const [editing, setEditing] = useState<Row | null>(null);
 
   const load = () => {
-    fetch(`${basePath}/api/questions`)
+    fetch(`${apiBasePath}/questions`)
       .then(res => res.json())
       .then(rows => setData(rows.map((r: any) => ({ key: r.id, ...r }))));
   };
@@ -41,7 +41,7 @@ export default function QuestionBank() {
         D: r[4],
         answer: r[5]
       }));
-      await fetch(`${basePath}/api/questions`, {
+      await fetch(`${apiBasePath}/questions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ questions: rows })
@@ -71,14 +71,14 @@ export default function QuestionBank() {
   };
 
   const remove = async (id: number) => {
-    await fetch(`${basePath}/api/questions/${id}`, { method: 'DELETE' });
+    await fetch(`${apiBasePath}/questions/${id}`, { method: 'DELETE' });
     load();
   };
 
   const saveEdit = async () => {
     if (!editing) return;
     const { key, ...payload } = editing;
-    await fetch(`${basePath}/api/questions/${key}`, {
+    await fetch(`${apiBasePath}/questions/${key}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)

--- a/docs/client/src/pages/Quiz.tsx
+++ b/docs/client/src/pages/Quiz.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Typography, Radio, Button } from 'antd';
-import { basePath } from '../config';
+import { apiBasePath } from '../config';
 
 interface Question {
   id: number;
@@ -15,7 +15,7 @@ export default function Quiz() {
   const [score, setScore] = useState<number | null>(null);
 
   useEffect(() => {
-    fetch(`${basePath}/api/questions`)
+    fetch(`${apiBasePath}/questions`)
       .then(res => res.json())
       .then(rows =>
         setQuestions(
@@ -35,7 +35,7 @@ export default function Quiz() {
       if (answers[q.id] === q.answer) sc++;
     });
     setScore(sc);
-    fetch(`${basePath}/api/results`, {
+    fetch(`${apiBasePath}/results`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ score: sc, total: questions.length })

--- a/docs/client/src/pages/Results.tsx
+++ b/docs/client/src/pages/Results.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Typography, Table } from 'antd';
-import { basePath } from '../config';
+import { apiBasePath } from '../config';
 
 interface Result {
   id: number;
@@ -13,7 +13,7 @@ export default function Results() {
   const [data, setData] = useState<Result[]>([]);
 
   useEffect(() => {
-    fetch(`${basePath}/api/results`)
+    fetch(`${apiBasePath}/results`)
       .then(res => res.json())
       .then(rows => setData(rows));
   }, []);

--- a/docs/server.js
+++ b/docs/server.js
@@ -5,6 +5,7 @@ const path = require('path');
 const sqlite3 = require('sqlite3').verbose();
 const dbFile = path.resolve(__dirname, 'questions.db');
 const basePath = '/lovework';
+const apiBasePath = '/lovework/api';
 
 async function start() {
   const app = express();
@@ -30,7 +31,7 @@ async function start() {
     )`);
   });
 
-  app.post(`${basePath}/chat`, (req, res) => {
+  app.post(`${apiBasePath}/chat`, (req, res) => {
     res.set({
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
@@ -52,14 +53,14 @@ async function start() {
       }
     }, 400);
   });
-  app.get(`${basePath}/api/questions`, (req, res) => {
+  app.get(`${apiBasePath}/questions`, (req, res) => {
     db.all('SELECT * FROM questions', (err, rows) => {
       if (err) return res.status(500).json({ error: err.message });
       res.json(rows);
     });
   });
 
-  app.post(`${basePath}/api/questions`, (req, res) => {
+  app.post(`${apiBasePath}/questions`, (req, res) => {
     const qs = req.body.questions || [];
     const stmt = db.prepare('INSERT INTO questions(question,A,B,C,D,answer) VALUES (?,?,?,?,?,?)');
     db.serialize(() => {
@@ -73,7 +74,7 @@ async function start() {
     });
   });
 
-  app.put(`${basePath}/api/questions/:id`, (req, res) => {
+  app.put(`${apiBasePath}/questions/:id`, (req, res) => {
     const id = req.params.id;
     const q = req.body;
     db.run(
@@ -86,21 +87,21 @@ async function start() {
     );
   });
 
-  app.delete(`${basePath}/api/questions/:id`, (req, res) => {
+  app.delete(`${apiBasePath}/questions/:id`, (req, res) => {
     db.run('DELETE FROM questions WHERE id=?', req.params.id, function (err) {
       if (err) return res.status(500).json({ error: err.message });
       res.json({ ok: true });
     });
   });
 
-  app.get(`${basePath}/api/results`, (req, res) => {
+  app.get(`${apiBasePath}/results`, (req, res) => {
     db.all('SELECT * FROM results ORDER BY id DESC', (err, rows) => {
       if (err) return res.status(500).json({ error: err.message });
       res.json(rows);
     });
   });
 
-  app.post(`${basePath}/api/results`, (req, res) => {
+  app.post(`${apiBasePath}/results`, (req, res) => {
     const { score, total } = req.body;
     db.run('INSERT INTO results(score,total) VALUES(?,?)', [score, total], function (err) {
       if (err) return res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- serve backend routes under `/lovework/api`
- update frontend to call the new API prefix

## Testing
- `npm --prefix docs install`
- `npm --prefix docs run build`


------
https://chatgpt.com/codex/tasks/task_e_686cc87edbf88324815b44359631cb10